### PR TITLE
Fix pid getopts parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
     let mut opts = Options::new();
 
     opts.parsing_style(ParsingStyle::StopAtFirstFree)
-        .optflagopt("p", "pid", "pid to send watchdog events for", "PID")
+        .optopt("p", "pid", "pid to send watchdog events for", "PID")
         .reqopt("c", "healthcheck", "Set healthcheck command", "COMMAND")
         .optflag("h", "help", "Print this help menu");
 


### PR DESCRIPTION
optflagopt results in the argument for --pid as optional.
We actually consider the arguement for --pid as required

Combined with ParsingStyle::StopAtFirstFree, we get an interesting
situation.

When healthdog spawns the helper with --pid PID, PID is considered
to be another argument and not part of --pid somehow.

As a result healthdog tries to respawn a new process called PID.

Fixed by making the arguement for --pid as optopt to make the argument
as required.

Change-type: patch
Changelog-entry: Fix for --pid parsing
Signed-off-by: Zubair Lutfullah Kakakhel <zubair@balena.io>