### PR TITLE
Remove panic="abort" as it breaks meta-rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,4 @@ nix = "0.15"
 [profile.release]
 opt-level = "z"
 lto = true
-panic = "abort"
 codegen-units = 1


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>